### PR TITLE
Update viewer progress bar layout and display

### DIFF
--- a/viewer.html
+++ b/viewer.html
@@ -56,6 +56,7 @@
         margin-top: 100px;
         padding: 2rem;
         margin-right: 300px;
+        padding-bottom: 96px;
       }
 
       .script-line {
@@ -243,6 +244,41 @@
         scrollbar-width: thin;
         scrollbar-color: rgba(66, 153, 225, 0.6) rgba(255, 255, 255, 0.1);
       }
+
+      /* Bottom progress bar */
+      .footer-info {
+        display: flex;
+        justify-content: space-between;
+        font-size: 18px;
+        color: #a0aec0;
+        margin-bottom: 6px;
+      }
+
+      .progress {
+        height: 24px;
+        border: 1px solid var(--highlight-color);
+        border-radius: 12px;
+        overflow: hidden;
+        background: rgba(255, 255, 255, 0.05);
+      }
+
+      .progress-bar {
+        height: 100%;
+        background: linear-gradient(90deg, #48bb78, var(--primary-color));
+        width: 0%;
+        transition: width 200ms ease-out;
+      }
+
+      .bottom-progress {
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        padding: 8px 16px;
+        background: var(--bg-color);
+        border-top: 2px solid var(--primary-color);
+        z-index: 120;
+      }
     </style>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.1/socket.io.js"></script>
@@ -258,6 +294,7 @@
 
       let markedLine = null
       let scriptData = null // Add global scriptData variable
+      let currentMarkerIndex = null
 
       // Socket.IO event handlers
       socket.on('connect', () => {
@@ -282,6 +319,7 @@
         // Find and mark the line
         const allLines = document.querySelectorAll('.script-line')
         if (allLines[data.index]) {
+          currentMarkerIndex = data.index
           markLine(allLines[data.index])
 
           // Update scene info based on the marked line
@@ -289,11 +327,14 @@
             const currentScene = scriptData[data.index].Szene
             updateSceneInfo(scriptData, currentScene)
           }
+          updateBottomProgress()
         }
       })
 
       socket.on('marker_clear', () => {
         clearMarkedLine()
+        currentMarkerIndex = null
+        updateBottomProgress()
       })
 
       socket.on('set_director', (data) => {
@@ -332,6 +373,34 @@
           markedLine.classList.remove('marked-line')
           markedLine = null
         }
+      }
+
+      function computeSceneProgressCounts() {
+        if (!scriptData || currentMarkerIndex === null) {
+          return { percent: 0, current: 0, total: 0 }
+        }
+        const row = scriptData[currentMarkerIndex]
+        if (!row || !row.Szene || row.Szene == 0) {
+          return { percent: 0, current: 0, total: 0 }
+        }
+        const sceneId = row.Szene
+        const sceneRows = scriptData
+          .map((r, idx) => ({ r, idx }))
+          .filter(({ r }) => r.Szene === sceneId && r.Szene != 0)
+        const total = sceneRows.length
+        if (total === 0) return { percent: 0, current: 0, total: 0 }
+        const pos = sceneRows.findIndex(({ idx }) => idx === currentMarkerIndex)
+        const current = Math.max(0, pos)
+        const percent = Math.floor((current / total) * 100)
+        return { percent, current, total }
+      }
+
+      function updateBottomProgress() {
+        const { percent, current, total } = computeSceneProgressCounts()
+        const bar = document.getElementById('global-progress-bar')
+        const text = document.getElementById('global-progress-text')
+        if (bar) bar.style.width = `${percent}%`
+        if (text) text.textContent = `${percent}% (${current}/${total})`
       }
 
       // Load and parse CSV
@@ -468,6 +537,9 @@
         // Start clock
         setInterval(updateClock, 1000)
         updateClock()
+
+        // Initialize progress
+        updateBottomProgress()
       }
 
       // Initialize when DOM is ready
@@ -695,6 +767,16 @@
 
     <div class="scene-info-sidebar">
       <!-- Scene information will be inserted here -->
+    </div>
+
+    <div class="bottom-progress">
+      <div class="footer-info">
+        <span>Fortschritt</span>
+        <span id="global-progress-text">0% (0/0)</span>
+      </div>
+      <div class="progress">
+        <div class="progress-bar" id="global-progress-bar"></div>
+      </div>
     </div>
   </body>
 </html>

--- a/viewer2.html
+++ b/viewer2.html
@@ -55,7 +55,7 @@
       }
 
       .content {
-        height: calc(100% - 80px);
+        height: calc(100% - 80px - 64px);
         display: grid;
         grid-template-columns: 1fr 1fr;
         gap: 16px;
@@ -157,6 +157,16 @@
         justify-content: space-between;
         font-size: 18px;
         color: #a0aec0;
+      }
+
+      .bottom-progress {
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        padding: 8px 16px;
+        background: var(--bg-color);
+        border-top: 2px solid var(--primary-color);
       }
     </style>
 
@@ -393,6 +403,31 @@
         return 100
       }
 
+      function computeSceneProgressCounts() {
+        if (currentMarkerIndex === null || currentMarkerIndex === undefined)
+          return { percent: 0, current: 0, total: 0 }
+        let remainingIndex = currentMarkerIndex
+        for (const [, indices] of sceneToIndices) {
+          const count = indices.length
+          if (count > remainingIndex) {
+            const current = Math.max(0, Math.min(remainingIndex, count))
+            const percent = count > 0 ? Math.floor((current / count) * 100) : 0
+            return { percent, current, total: count }
+          } else {
+            remainingIndex -= count
+          }
+        }
+        return { percent: 100, current: 0, total: 0 }
+      }
+
+      function updateBottomProgress() {
+        const { percent, current, total } = computeSceneProgressCounts()
+        const bar = document.getElementById('global-progress-bar')
+        const text = document.getElementById('global-progress-text')
+        if (bar) bar.style.width = `${percent}%`
+        if (text) text.textContent = `${percent}% (${current}/${total})`
+      }
+
       function getSceneFromMarker() {
         let currentIdx = currentMarkerIndex
         for (const [idx, items] of sceneToIndices) {
@@ -433,16 +468,7 @@
           rolesContainer.appendChild(ul)
         }
 
-        // Progress (only for current scene box)
-        if (box.id === 'current-scene-box') {
-          const p = computeProgress()
-          const bar = box.querySelector('.progress-bar')
-          if (bar) {
-            bar.style.width = `${p}%`
-          }
-          const footerPct = box.querySelector('.footer-info span:last-child')
-          if (footerPct) footerPct.textContent = `${p}%`
-        }
+        // Progress handled globally at bottom bar
 
         // Auto-scroll long sections
         // Stop previous intervals and start new ones after DOM update
@@ -457,6 +483,7 @@
         const nextScene = getNextScene(currentScene)
         renderSceneBox('current-scene-box', 'Szene', currentScene)
         renderSceneBox('next-scene-box', 'Nächste Szene', nextScene)
+        updateBottomProgress()
       }
 
       function initSocket() {
@@ -490,6 +517,7 @@
 
         socket.on('marker_clear', () => {
           currentMarkerIndex = null
+          updateBottomProgress()
         })
       }
 
@@ -539,13 +567,6 @@
           <div class="section-title">Rollen (mit Schauspieler)</div>
           <div class="roles-list"></div>
         </div>
-        <div class="footer-info">
-          <span>Fortschritt</span>
-          <span></span>
-        </div>
-        <div class="progress">
-          <div class="progress-bar"></div>
-        </div>
       </div>
 
       <div id="next-scene-box" class="scene-panel">
@@ -555,6 +576,16 @@
           <div class="section-title">Rollen (mit Schauspieler)</div>
           <div class="roles-list"></div>
         </div>
+      </div>
+    </div>
+
+    <div class="bottom-progress">
+      <div class="footer-info">
+        <span>Fortschritt</span>
+        <span id="global-progress-text">0% (0/0)</span>
+      </div>
+      <div class="progress">
+        <div class="progress-bar" id="global-progress-bar"></div>
       </div>
     </div>
   </body>


### PR DESCRIPTION
Move the scene progress bar to the bottom of the page, make it full width, and display action counts.

---
<a href="https://cursor.com/background-agent?bcId=bc-08b96271-4f9f-45c8-a509-9ccc4865e7bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-08b96271-4f9f-45c8-a509-9ccc4865e7bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

