### PR TITLE
Support multiple plays and director mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,6 +157,15 @@
             </div>
           </div>
 
+          <div>
+            <label for="play-select">Stück auswählen:</label>
+            <div class="select-container">
+              <select id="play-select">
+                <option value="default">Standardstück</option>
+              </select>
+            </div>
+          </div>
+
           <div class="checkbox-group">
             <input type="checkbox" id="show-actor-names" />
             <label for="show-actor-names">Akteurnamen zu Rollennamen anzeigen</label>
@@ -260,7 +269,7 @@
 
             <!-- Link to Suggestor -->
             <div class="checkbox-group">
-              <a href="suggestor.html" class="button">Rollenvorschläge für die Probe</a>
+            <a id="suggestor-link" href="suggestor.html" class="button">Rollenvorschläge für die Probe</a>
             </div>
           </div>
 

--- a/plays.json
+++ b/plays.json
@@ -1,0 +1,6 @@
+{
+  "default": {
+    "name": "Standardstück",
+    "sheet": "https://docs.google.com/spreadsheets/d/1LEhNzES1aLQ_UVA8esjXcGgkK3I5gv3q/export?format=csv&gid=967194980"
+  }
+}

--- a/suggestor.html
+++ b/suggestor.html
@@ -190,14 +190,36 @@
         }
       }
 
+      // Multi-play support
+      const urlParams = new URLSearchParams(window.location.search)
+      const storedPlayId = localStorage.getItem('playId') || 'default'
+      const playId = urlParams.get('play') || storedPlayId
+      if (urlParams.get('play')) localStorage.setItem('playId', playId)
+      let playsConfig = null
+      let sheetUrl = null
+
+      async function loadPlaysConfig() {
+        try {
+          const res = await fetch('plays.json')
+          if (res.ok) playsConfig = await res.json()
+        } catch (e) {}
+        if (!playsConfig) {
+          playsConfig = {
+            default: {
+              name: 'Standardstück',
+              sheet:
+                'https://docs.google.com/spreadsheets/d/1LEhNzES1aLQ_UVA8esjXcGgkK3I5gv3q/export?format=csv&gid=967194980',
+            },
+          }
+        }
+      }
+
       async function loadScript() {
         try {
           // Load character map first
           await loadCharacterMap()
 
-          const response = await fetch(
-            'https://docs.google.com/spreadsheets/d/1LEhNzES1aLQ_UVA8esjXcGgkK3I5gv3q/export?format=csv&gid=967194980'
-          )
+          const response = await fetch(sheetUrl)
           if (!response.ok) throw new Error('Network response was not ok')
 
           const csvText = await response.text()
@@ -364,7 +386,13 @@
       }
 
       // Initialize
-      loadScript()
+      ;(async () => {
+        await loadPlaysConfig()
+        sheetUrl =
+          (playsConfig && playsConfig[playId] && playsConfig[playId].sheet) ||
+          (playsConfig && playsConfig.default && playsConfig.default.sheet)
+        await loadScript()
+      })()
     </script>
   </body>
 </html>

--- a/viewer.html
+++ b/viewer.html
@@ -336,6 +336,30 @@
         updateDirectorStatus(data.director)
       })
 
+      // Multi-play support
+      const urlParams = new URLSearchParams(window.location.search)
+      const storedPlayId = localStorage.getItem('playId') || 'default'
+      const playId = urlParams.get('play') || storedPlayId
+      if (urlParams.get('play')) localStorage.setItem('playId', playId)
+      let playsConfig = null
+      let sheetUrl = null
+
+      async function loadPlaysConfig() {
+        try {
+          const res = await fetch('plays.json')
+          if (res.ok) playsConfig = await res.json()
+        } catch (e) {}
+        if (!playsConfig) {
+          playsConfig = {
+            default: {
+              name: 'Standardstück',
+              sheet:
+                'https://docs.google.com/spreadsheets/d/1LEhNzES1aLQ_UVA8esjXcGgkK3I5gv3q/export?format=csv&gid=967194980',
+            },
+          }
+        }
+      }
+
       // Helper functions
       function updateConnectionStatus(status) {
         const statusEl = document.getElementById('connection-status')
@@ -401,9 +425,7 @@
       // Load and parse CSV
       async function loadScript() {
         try {
-          const response = await fetch(
-            'https://docs.google.com/spreadsheets/d/1LEhNzES1aLQ_UVA8esjXcGgkK3I5gv3q/export?format=csv&gid=967194980'
-          )
+          const response = await fetch(sheetUrl)
 
           if (!response.ok) {
             throw new Error('Network response was not ok')
@@ -526,6 +548,11 @@
 
       // Initialize
       async function init() {
+        await loadPlaysConfig()
+        sheetUrl =
+          (playsConfig && playsConfig[playId] && playsConfig[playId].sheet) ||
+          (playsConfig && playsConfig.default && playsConfig.default.sheet)
+
         scriptData = await loadScript() // Store in global variable
         window.actors = getActors(scriptData)
         renderScript(scriptData)
@@ -537,6 +564,11 @@
 
         // Initialize progress
         updateBottomProgress()
+
+        // Join per-play room after socket connects
+        socket.on('connect', () => {
+          try { socket.emit('join_play', { playId }) } catch (e) {}
+        })
       }
 
       // Initialize when DOM is ready

--- a/viewer2.html
+++ b/viewer2.html
@@ -237,11 +237,33 @@
         if (el) el.textContent = `Director: ${name || 'Niemand'}`
       }
 
+      // Multi-play support
+      const urlParams = new URLSearchParams(window.location.search)
+      const storedPlayId = localStorage.getItem('playId') || 'default'
+      const playId = urlParams.get('play') || storedPlayId
+      if (urlParams.get('play')) localStorage.setItem('playId', playId)
+      let playsConfig = null
+      let sheetUrl = null
+
+      async function loadPlaysConfig() {
+        try {
+          const res = await fetch('plays.json')
+          if (res.ok) playsConfig = await res.json()
+        } catch (e) {}
+        if (!playsConfig) {
+          playsConfig = {
+            default: {
+              name: 'Standardstück',
+              sheet:
+                'https://docs.google.com/spreadsheets/d/1LEhNzES1aLQ_UVA8esjXcGgkK3I5gv3q/export?format=csv&gid=967194980',
+            },
+          }
+        }
+      }
+
       async function loadScript() {
         try {
-          const response = await fetch(
-            'https://docs.google.com/spreadsheets/d/1LEhNzES1aLQ_UVA8esjXcGgkK3I5gv3q/export?format=csv&gid=967194980'
-          )
+          const response = await fetch(sheetUrl)
           if (!response.ok) throw new Error('Network response was not ok')
           const csvText = await response.text()
           const data = Papa.parse(csvText, { header: true }).data
@@ -497,6 +519,7 @@
 
         socket.on('connect', () => {
           updateConnectionStatus('Verbunden')
+          try { socket.emit('join_play', { playId }) } catch (e) {}
         })
         socket.on('connect_error', () => {
           updateConnectionStatus('Verbindungsfehler')
@@ -524,6 +547,11 @@
 
       async function init() {
         await ensurePapaLoaded()
+        await loadPlaysConfig()
+        sheetUrl =
+          (playsConfig && playsConfig[playId] && playsConfig[playId].sheet) ||
+          (playsConfig && playsConfig.default && playsConfig.default.sheet)
+
         updateConnectionStatus('Verbinde...')
         scriptData = normalizeData(await loadScript())
         roleToActor = buildRoleMapping(scriptData)


### PR DESCRIPTION
Add support for multiple plays (sheet URLs) and isolate director mode state per play.

This is achieved by introducing per-play Socket.IO rooms on the server and client, dynamically loading sheet URLs from a `plays.json` configuration, and updating client-side caching to be play-specific.

---
<a href="https://cursor.com/background-agent?bcId=bc-f109345a-3387-47f2-91f0-afd2efe275fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f109345a-3387-47f2-91f0-afd2efe275fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

